### PR TITLE
Checking coding style and error using venv-lint

### DIFF
--- a/staking_deposit/credentials.py
+++ b/staking_deposit/credentials.py
@@ -38,6 +38,7 @@ from eth_account import Account
 
 from Crypto.Hash import keccak
 
+
 class WithdrawalType(Enum):
     BLS_WITHDRAWAL = 0
     ETH1_ADDRESS_WITHDRAWAL = 1
@@ -71,7 +72,6 @@ class Credential:
         keccak_hash.update(self.secret)
         hash_str = keccak_hash.hexdigest()
         self.secret_eth1 = bytes.fromhex(hash_str)
-
 
     @property
     def signing_pk(self) -> bytes:
@@ -149,7 +149,7 @@ class Credential:
         voter = bytes.fromhex(hex_string)
         return VoterMessage(
             pubkey=self.signing_pk,
-            voter = voter,
+            voter=voter,
             amount=self.amount,
         )
 
@@ -204,7 +204,8 @@ class Credential:
 
         eth1_keystore = self.signing_eth1_keystore(password)
         self.voter = eth1_keystore['address']
-        eht1_filefolder = os.path.join(folder, 'keystore-%s-%i-voter.json' % (keystore.path.replace('/', '_'), gen_time))
+        eht1_filefolder = \
+            os.path.join(folder, 'keystore-%s-%i-voter.json' % (keystore.path.replace('/', '_'), gen_time))
         with open(eht1_filefolder, 'w') as f:
             json.dump(eth1_keystore, f)
         return filefolder


### PR DESCRIPTION
I executed `make venv_lint`

output:
```
./staking_deposit/credentials.py:41:1: E302 expected 2 blank lines, found 1
./staking_deposit/credentials.py:76:5: E303 too many blank lines (2)
./staking_deposit/credentials.py:152:18: E251 unexpected spaces around keyword / parameter equals
./staking_deposit/credentials.py:152:20: E251 unexpected spaces around keyword / parameter equals
./staking_deposit/credentials.py:207:121: E501 line too long (121 > 120 characters)
```